### PR TITLE
refactor(exception): replace NewDefaultApiError with NewApiError for …

### DIFF
--- a/api/internal/service/impl/MultiChoiceLessonServiceImpl.go
+++ b/api/internal/service/impl/MultiChoiceLessonServiceImpl.go
@@ -2,6 +2,7 @@ package impl
 
 import (
 	"encoding/json"
+	"errors"
 	"smart-elearning/internal/dto/common"
 	"smart-elearning/internal/dto/request"
 	"smart-elearning/internal/dto/response"
@@ -43,24 +44,24 @@ func (lessonService *MultiChoiceLessonServiceImpl) CreateLesson(
 	}
 
 	if !isOwner {
-		return nil, exception.NewDefaultApiError(responseStatus.ACCESS_DENIED)
+		return nil, exception.NewApiError(responseStatus.ACCESS_DENIED, nil)
 	}
 
 	multiChoiceLesson, err := mapper.RequestToMultiChoiceLesson(courseId, request)
 
 	if err != nil {
-		return nil, exception.NewDefaultApiError(responseStatus.CREATE_LESSON_ERROR)
+		return nil, exception.NewApiError(responseStatus.CREATE_LESSON_ERROR, nil)
 	}
 
 	newMultiChoiceLesson, err := lessonService.multiChoiceLessonRepository.Save(multiChoiceLesson)
 
 	if err != nil {
-		return nil, exception.NewDefaultApiError(responseStatus.CREATE_LESSON_ERROR)
+		return nil, exception.NewApiError(responseStatus.CREATE_LESSON_ERROR, nil)
 	}
 
 	lessonInfoResponse, err := mapper.ToMultiChoiceLessonInfoResponse(newMultiChoiceLesson, 0)
 	if err != nil {
-		return nil, exception.NewDefaultApiError(responseStatus.CREATE_LESSON_ERROR)
+		return nil, exception.NewApiError(responseStatus.CREATE_LESSON_ERROR, nil)
 	}
 
 	return lessonInfoResponse, nil
@@ -77,7 +78,7 @@ func (lessonService *MultiChoiceLessonServiceImpl) UpdateQuestions(
 	}
 
 	if !isOwner {
-		return nil, exception.NewDefaultApiError(responseStatus.ACCESS_DENIED)
+		return nil, exception.NewApiError(responseStatus.ACCESS_DENIED, nil)
 	}
 
 	var questions []*entity.MultiChoiceQuestion
@@ -86,12 +87,12 @@ func (lessonService *MultiChoiceLessonServiceImpl) UpdateQuestions(
 
 		answersJSON, err := json.Marshal(requestQuestion.Answers)
 		if err != nil {
-			return nil, exception.NewApiError(responseStatus.JSON_PROCESSING_ERROR, "Failed to marshal answers: "+err.Error())
+			return nil, exception.NewApiError(responseStatus.JSON_PROCESSING_ERROR, errors.New("Failed to marshal answers: "+err.Error()))
 		}
 
 		correctAnswersJSON, err := json.Marshal(requestQuestion.CorrectAnswers)
 		if err != nil {
-			return nil, exception.NewApiError(responseStatus.JSON_PROCESSING_ERROR, "Failed to marshal correct answers: "+err.Error())
+			return nil, exception.NewApiError(responseStatus.JSON_PROCESSING_ERROR, errors.New("Failed to marshal correct answers: "+err.Error()))
 		}
 
 		newQuestion := entity.MultiChoiceQuestion{

--- a/api/pkg/exception/ApiError.go
+++ b/api/pkg/exception/ApiError.go
@@ -2,6 +2,7 @@ package exception
 
 import (
 	"errors"
+	"fmt"
 	"smart-elearning/pkg/response"
 )
 
@@ -11,13 +12,6 @@ type ApiError struct {
 }
 
 func NewApiError(responseCode int, err error) *ApiError {
-	return &ApiError{
-		ResponseCode: responseCode,
-		Err:          err,
-	}
-}
-
-func NewDefaultApiError(responseCode int, err error) *ApiError {
 	var wrappedErr error
 	if err != nil {
 		wrappedErr = fmt.Errorf("%s: %w", response.ResponseMessage[responseCode].Message, err)

--- a/api/pkg/response/ResponseStatus.go
+++ b/api/pkg/response/ResponseStatus.go
@@ -24,6 +24,7 @@ const (
 	JOIN_COURSE_ERROR         = 1012
 	GET_COURSE_MEMBERS_ERROR  = 1013
 	CREATE_LESSON_ERROR       = 1014
+	JSON_PROCESSING_ERROR     = 1015
 )
 
 var ResponseMessage = map[int]ResponseStatus{
@@ -43,4 +44,5 @@ var ResponseMessage = map[int]ResponseStatus{
 	JOIN_COURSE_ERROR:         {StatusCode: http.StatusInternalServerError, Message: "Join to course failed."},
 	GET_COURSE_MEMBERS_ERROR:  {StatusCode: http.StatusInternalServerError, Message: "Cannot get course members. Internal server error"},
 	CREATE_LESSON_ERROR:       {StatusCode: http.StatusInternalServerError, Message: "Cannot create lesson. Internal server error"},
+	JSON_PROCESSING_ERROR:     {StatusCode: http.StatusInternalServerError, Message: "Json processing error"},
 }


### PR DESCRIPTION
This pull request introduces improvements to error handling and updates the response status codes in the `MultiChoiceLessonServiceImpl` and related files. The most significant changes include replacing `NewDefaultApiError` with `NewApiError` across the codebase, adding a new `JSON_PROCESSING_ERROR` response status, and enhancing error wrapping for better debugging.

### Error Handling Improvements:
* Replaced `NewDefaultApiError` with `NewApiError` in `MultiChoiceLessonServiceImpl` methods to provide more detailed error information. This change affects `CreateLesson` and `UpdateQuestions` methods. [[1]](diffhunk://#diff-e5f5dc865a185ecc0df49d8890f86e59fe9150d67b417dbfa59e0e76db333582L46-R64) [[2]](diffhunk://#diff-e5f5dc865a185ecc0df49d8890f86e59fe9150d67b417dbfa59e0e76db333582L80-R81)
* Updated error wrapping in `UpdateQuestions` to use `errors.New` for consistent error message formatting when marshaling JSON fails.

### Response Status Updates:
* Added a new `JSON_PROCESSING_ERROR` constant (`1015`) to `ResponseStatus` for better classification of JSON-related errors.
* Extended the `ResponseMessage` map to include a message for `JSON_PROCESSING_ERROR`.

### Code Simplification:
* Removed the `NewDefaultApiError` function from `ApiError.go`, consolidating error creation logic into `NewApiError`.