### PR TITLE
Binds server to all interfaces

### DIFF
--- a/api/internal/initialize/run.go
+++ b/api/internal/initialize/run.go
@@ -56,7 +56,7 @@ func Run() {
 	)
 
 	/* START APPLICATION */
-	err := r.Run("localhost:8080")
+	err := r.Run(":8080")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Updates the server binding address to listen on all available network interfaces.

This change removes the "localhost" prefix from the binding address, allowing the server to accept connections from external sources.