### PR TITLE
Feature/api v2/add dockerfile

### DIFF
--- a/.github/workflows/backend-v2-build-push.yml
+++ b/.github/workflows/backend-v2-build-push.yml
@@ -6,21 +6,28 @@ on:
         paths:
             - /api-v2/smart-elearning/**
             - .github/workflows/backend-v2-build-push.yml
+
 jobs:
     build:
         runs-on: ubuntu-latest
         steps:
             - name: checkout
               uses: actions/checkout@v4
+
             - name: Set up JDK 17
               uses: actions/setup-java@v4
               with:
                   java-version: "17"
                   distribution: "temurin"
                   cache: maven
+
+            - name: Build with Maven
+              run: mvn clean package
+
             - name: Build the Docker image
               working-directory: ./api-v2/smart-elearning
               run: docker build . --file Dockerfile --tag zeustakeshi/smart-elearning-backend:latest
+
             - name: login Dockerhub
               run: |
                   docker login -u "zeustakeshi" -p ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/backend-v2-build-push.yml
+++ b/.github/workflows/backend-v2-build-push.yml
@@ -4,7 +4,7 @@ on:
         branches:
             - feature/api/create-api-v2-with-java
         paths:
-            - /api-v2/smart-elearning
+            - /api-v2/smart-elearning/**
             - .github/workflows/backend-v2-build-push.yml
 jobs:
     build:

--- a/.github/workflows/backend-v2-build-push.yml
+++ b/.github/workflows/backend-v2-build-push.yml
@@ -22,6 +22,7 @@ jobs:
                   cache: maven
 
             - name: Build with Maven
+              working-directory: ./api-v2/smart-elearning
               run: mvn clean package
 
             - name: Build the Docker image

--- a/api-v2/smart-elearning/Dockerfile
+++ b/api-v2/smart-elearning/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk-slim
+LABEL authors="Minhhieuano"
+LABEL description="Smart-elearning"
+COPY target/*.jar app.jar
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-jar", "/app.jar"]


### PR DESCRIPTION
This pull request introduces changes to the build pipeline for the `smart-elearning` API and adds a new `Dockerfile` to containerize the application. The most important changes include updating the workflow configuration to monitor all subdirectories in `api-v2/smart-elearning` and defining the Docker image setup for the application.

### Workflow configuration updates:
* [`.github/workflows/backend-v2-build-push.yml`](diffhunk://#diff-8f7bf1961131c6f25be771ac0ae5cc1eb76e40d4fe05f46d1fdf09495a3f1190L7-R7): Modified the `paths` configuration to include all subdirectories under `api-v2/smart-elearning` (`api-v2/smart-elearning/**`).

### Dockerfile addition:
* [`api-v2/smart-elearning/Dockerfile`](diffhunk://#diff-0e685d1deb1a6cba98222cc0648184fa5e8bcf9d79166e1f07886e8af79a5072R1-R5): Added a new Dockerfile to define the container setup for the `smart-elearning` application, using the `openjdk:17-jdk-slim` base image, copying the application `.jar` file, and setting up the entry point for running the application.